### PR TITLE
Add deserializeCompactV2 method to deserialize block with 32-byte chain work

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -137,7 +137,7 @@ public class CheckpointManager {
             for (int i = 0; i < numCheckpoints; i++) {
                 if (dis.read(buffer.array(), 0, size) < size)
                     throw new IOException("Incomplete read whilst loading checkpoints.");
-                StoredBlock block = StoredBlock.deserializeCompact(params, buffer);
+                StoredBlock block = StoredBlock.deserializeCompactLegacy(params, buffer);
                 buffer.position(0);
                 checkpoints.put(block.getHeader().getTimeSeconds(), block);
             }
@@ -176,7 +176,7 @@ public class CheckpointManager {
                 buffer.position(0);
                 buffer.put(bytes);
                 buffer.position(0);
-                StoredBlock block = StoredBlock.deserializeCompact(params, buffer);
+                StoredBlock block = StoredBlock.deserializeCompactLegacy(params, buffer);
                 checkpoints.put(block.getHeader().getTimeSeconds(), block);
             }
             HashCode hash = hasher.hash();

--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -155,9 +155,32 @@ public class StoredBlock {
         buffer.put(bytes, 0, Block.HEADER_SIZE);  // Trim the trailing 00 byte (zero transactions).
     }
 
-    /** De-serializes the stored block from a custom packed format. Used by {@link CheckpointManager}. */
+    /**
+     * Deserializes the stored block from a custom packed format. Used internally.
+     * As of June 22, 2024, it takes 12 unsigned bytes to store the chain work value,
+     * so developers should use the V2 format.
+     *
+     * @param buffer data to deserialize
+     * @return deserialized stored block
+     */
     public static StoredBlock deserializeCompact(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
         byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_V1];
+        buffer.get(chainWorkBytes);
+        BigInteger chainWork = new BigInteger(1, chainWorkBytes);
+        int height = buffer.getInt();  // +4 bytes
+        byte[] header = new byte[Block.HEADER_SIZE + 1];    // Extra byte for the 00 transactions length.
+        buffer.get(header, 0, Block.HEADER_SIZE);
+        return new StoredBlock(params.getDefaultSerializer().makeBlock(header), chainWork, height);
+    }
+
+    /**
+     * Deserializes the stored block from a custom packed format. Used internally.
+     *
+     * @param buffer data to deserialize
+     * @return deserialized stored block
+     */
+    public static StoredBlock deserializeCompactV2(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
+        byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_V2];
         buffer.get(chainWorkBytes);
         BigInteger chainWork = new BigInteger(1, chainWorkBytes);
         int height = buffer.getInt();  // +4 bytes

--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -156,6 +156,8 @@ public class StoredBlock {
     }
 
     /**
+     * @deprecated Use {@link #deserializeCompactV2(NetworkParameters, ByteBuffer)} instead.
+     *
      * Deserializes the stored block from a custom packed format. Used internally.
      * As of June 22, 2024, it takes 12 unsigned bytes to store the chain work value,
      * so developers should use the V2 format.
@@ -163,7 +165,8 @@ public class StoredBlock {
      * @param buffer data to deserialize
      * @return deserialized stored block
      */
-    public static StoredBlock deserializeCompact(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
+    @Deprecated
+    public static StoredBlock deserializeCompactLegacy(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
         byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_V1];
         buffer.get(chainWorkBytes);
         BigInteger chainWork = new BigInteger(1, chainWorkBytes);

--- a/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
@@ -88,7 +88,7 @@ public class LevelDBBlockStore implements BlockStore {
         byte[] bits = db.get(hash.getBytes());
         if (bits == null)
             return null;
-        return StoredBlock.deserializeCompact(context.getParams(), ByteBuffer.wrap(bits));
+        return StoredBlock.deserializeCompactLegacy(context.getParams(), ByteBuffer.wrap(bits));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
@@ -640,7 +640,7 @@ public class LevelDBFullPrunedBlockStore implements FullPrunedBlockStore {
         }
         // TODO Should I chop the last byte off? Seems to work with it left
         // there...
-        StoredBlock stored = StoredBlock.deserializeCompact(params, ByteBuffer.wrap(result));
+        StoredBlock stored = StoredBlock.deserializeCompactLegacy(params, ByteBuffer.wrap(result));
         stored.getHeader().verifyHeader();
 
         if (instrument)

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -233,7 +233,7 @@ public class SPVBlockStore implements BlockStore {
                 buffer.get(scratch);
                 if (Arrays.equals(scratch, targetHashBytes)) {
                     // Found the target.
-                    StoredBlock storedBlock = StoredBlock.deserializeCompact(params, buffer);
+                    StoredBlock storedBlock = StoredBlock.deserializeCompactLegacy(params, buffer);
                     blockCache.put(hash, storedBlock);
                     return storedBlock;
                 }

--- a/core/src/test/java/org/bitcoinj/core/StoredBlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/StoredBlockTest.java
@@ -156,41 +156,45 @@ public class StoredBlockTest {
     }
 
     @Test
-    public void serializeCompactV2_forZeroChainWork_works() {
-        testSerializeCompactV2(ZERO_CHAIN_WORK);
+    public void serializeAndDeserializeCompactV2_forZeroChainWork_works() {
+        testSerializeAndDeserializeCompactV2(ZERO_CHAIN_WORK);
     }
 
     @Test
-    public void serializeCompactV2_forSmallChainWork_works() {
-        testSerializeCompactV2(SMALL_CHAIN_WORK);
+    public void serializeAndDeserializeCompactV2_forSmallChainWork_works() {
+        testSerializeAndDeserializeCompactV2(SMALL_CHAIN_WORK);
     }
 
     @Test
-    public void serializeCompactV2_for8BytesChainWork_works() {
-        testSerializeCompactV2(EIGHT_BYTES_WORK_V1);
+    public void serializeAndDeserializeCompactV2_for8BytesChainWork_works() {
+        testSerializeAndDeserializeCompactV2(EIGHT_BYTES_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_for12ByteChainWork_works() {
-        testSerializeCompactV2(MAX_WORK_V1);
+    public void serializeAndDeserializeCompactV2_for12ByteChainWork_works() {
+        testSerializeAndDeserializeCompactV2(MAX_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_forTooLargeWorkV1_works() {
-        testSerializeCompactV2(TOO_LARGE_WORK_V1);
+    public void serializeAndDeserializeCompactV2_forTooLargeWorkV1_works() {
+        testSerializeAndDeserializeCompactV2(TOO_LARGE_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_for32BytesChainWork_works() {
-        testSerializeCompactV2(MAX_WORK_V2);
+    public void serializeAndDeserializeCompactV2_for32BytesChainWork_works() {
+        testSerializeAndDeserializeCompactV2(MAX_WORK_V2);
     }
 
-    private void testSerializeCompactV2(BigInteger chainWork) {
+    private void testSerializeAndDeserializeCompactV2(BigInteger chainWork) {
         StoredBlock blockToStore = new StoredBlock(block, chainWork, 0);
         ByteBuffer buf = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE_V2);
         blockToStore.serializeCompactV2(buf);
         // assert serialized size and that the buffer is full
         assertEquals(StoredBlock.COMPACT_SERIALIZED_SIZE_V2, buf.position());
+
+        buf.rewind();
+        StoredBlock deserializedBlock = StoredBlock.deserializeCompactV2(mainnet, buf);
+        assertEquals(deserializedBlock, blockToStore);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/StoredBlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/StoredBlockTest.java
@@ -76,7 +76,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -90,7 +90,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -104,7 +104,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -118,7 +118,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 


### PR DESCRIPTION
## Description

- Add deserializeCompactV2 method to deserialize block with 32-byte chain work
- Add tests for deserializeCompactV2

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
